### PR TITLE
Fix cases that trying to parse URIs with host and port without scheme prefix like vm-app1:4740, add tests for more cases

### DIFF
--- a/Vostok.Commons.Helpers.Tests/Url/UrlParser_Tests.cs
+++ b/Vostok.Commons.Helpers.Tests/Url/UrlParser_Tests.cs
@@ -31,7 +31,7 @@ namespace Vostok.Commons.Helpers.Tests.Url
         [Test]
         public void Parse_should_parse_urls()
         {
-            var urls = new List<string> {"http://vm-app1:4740/", "http://vm-app2:4740/", "http://vm-app3:4741/"};
+            var urls = new List<string> {"http://vm-app1:4740/", "http://vm-app2:4740/", "http://vm-app3:4741/", "http://host.com/", "http://host"};
             UrlParser.Parse(urls).Should().BeEquivalentTo(urls.Select(u => new Uri(u)));
         }
 
@@ -46,6 +46,13 @@ namespace Vostok.Commons.Helpers.Tests.Url
         public void Parse_should_not_parse_null_urls()
         {
             UrlParser.Parse((IEnumerable<string>)null).Should().BeNull();
+        }
+
+        [Test]
+        public void Parse_should_not_parse_urls_without_scheme()
+        {
+            var urls = new List<string> {"vm-app1:4740/path/", "vm-app1:4740", "host.com", "host.domain.com", "host.com/path/", "clusterconfig", "clusterconfig/path"};
+            UrlParser.Parse(urls).Should().BeEmpty();
         }
     }
 }

--- a/Vostok.Commons.Helpers/Url/UrlParser.cs
+++ b/Vostok.Commons.Helpers/Url/UrlParser.cs
@@ -15,9 +15,10 @@ namespace Vostok.Commons.Helpers.Url
 
         public static Uri Parse(string url)
         {
-            return !Uri.TryCreate(url, UriKind.Absolute, out var parsed)
-                ? null
-                : parsed;
+            var uri = !Uri.TryCreate(url, UriKind.Absolute, out var parsed) ? null : parsed;
+            if (uri == null || string.IsNullOrEmpty(uri.Host) || uri.Port == -1)
+                return null;
+            return uri;
         }
     }
 }


### PR DESCRIPTION
Нашел использования в сниче и хьюстоне. Посмотрел, вроде ничего не аффектит.